### PR TITLE
chore: repo governance, CI, and community health files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# .github/CODEOWNERS
+# Automatically requests review from the listed owner(s) when matching files change.
+# Last matching rule wins. See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @mamukfurkan
+
+/.github/   @mamukfurkan
+/spec/      @mamukfurkan
+/corpus/    @mamukfurkan
+/crates/    @mamukfurkan

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,74 @@
+name: Bug Report
+description: Something isn't working as expected
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in as much detail as you can.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+      placeholder: When I do X, Y happens instead of Z.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps that reliably reproduce the issue.
+      placeholder: |
+        1. Create a schema with...
+        2. Run `vexilc schema.vexil`
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include full error output if available.
+    validations:
+      required: true
+
+  - type: textarea
+    id: schema
+    attributes:
+      label: Minimal Schema
+      description: The smallest `.vexil` schema that reproduces the issue, if applicable.
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      value: |
+        - OS:
+        - vexilc version (or git SHA):
+        - rustc version:
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Anything else that might help — logs, related issues, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a Question
+    url: https://github.com/vexil-lang/vexil/discussions
+    about: Use GitHub Discussions for questions and ideas
+  - name: Language Specification
+    url: https://github.com/vexil-lang/vexil/blob/master/spec/vexil-spec.md
+    about: Read the Vexil language specification before reporting spec-related issues

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,71 @@
+name: Feature Request
+description: Propose a new feature or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before requesting a feature, please check if it's already been discussed in
+        [Discussions](https://github.com/vexil-lang/vexil/discussions) or in the
+        [language specification](https://github.com/vexil-lang/vexil/blob/master/spec/vexil-spec.md).
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the project does this relate to?
+      options:
+        - Language (syntax / semantics)
+        - Type system / encoding
+        - Compiler library (vexil-lang)
+        - CLI (vexilc)
+        - Specification / grammar
+        - Corpus / tests
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: What problem does this feature solve? What's the use case?
+      placeholder: I'm trying to express X in a schema, but currently I can't because...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the feature you'd like to see. Include example syntax if applicable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds you've tried?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Nice to have
+        - Important
+        - Blocking my use case
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Prior art in other schema languages, links, examples, etc.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Summary
+
+Closes #<!-- issue number, if applicable -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change
+- [ ] Spec or grammar change
+- [ ] Corpus addition (valid or invalid)
+- [ ] Documentation update
+- [ ] Refactor / cleanup
+- [ ] CI / build changes
+
+## Testing
+
+- [ ] Existing tests pass (`cargo test --workspace`)
+- [ ] Added tests for new behavior
+- [ ] Corpus files added or updated (and `corpus/MANIFEST.md` updated)
+- [ ] Tested manually (describe below if relevant)
+
+## Checklist
+
+- [ ] Code is formatted (`cargo fmt --all`)
+- [ ] No new Clippy warnings (`cargo clippy --workspace -- -D warnings`)
+- [ ] Public API changes have doc comments
+- [ ] `CHANGELOG.md` updated
+
+## Notes

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ['*']
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --workspace
+
+      - name: Test
+        run: cargo test --workspace
+
+      - name: Clippy
+        run: cargo clippy --workspace -- -D warnings
+
+      - name: Format check
+        run: cargo fmt --all -- --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact: vexilc.exe
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: vexilc
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: vexilc
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Add target
+        run: rustup target add ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --release --bin vexilc --target ${{ matrix.target }}
+
+      - name: Stage artifact
+        shell: bash
+        run: |
+          BIN="target/${{ matrix.target }}/release/${{ matrix.artifact }}"
+          OUT="vexilc-${{ matrix.target }}"
+          [[ "${{ matrix.artifact }}" == *.exe ]] && OUT="${OUT}.exe"
+          cp "$BIN" "$OUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vexilc-${{ matrix.target }}
+          path: vexilc-${{ matrix.target }}*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*
+          generate_release_notes: true
+          draft: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Full compiler pipeline: lexer, parser, AST, lowering pass, IR, and type checker
+- `vexil_lang::parse()` — parses and semantically validates a `.vexil` source string
+- `vexil_lang::compile()` — full pipeline through IR and type checking
+- IR type definitions and `ErrorClass` variants covering all 56 invalid corpus cases
+- Type checker: wire size computation and recursive type detection
+- Lowering pass: AST → IR name resolution and `compile()` API
+- Semantic validation — all 74 corpus tests passing (18 valid, 56 invalid)
+- `vexilc` CLI with [ariadne](https://github.com/zesterer/ariadne) error rendering
+- Formal PEG grammar (`spec/vexil-grammar.peg`) derived from the language specification
+- 74-file conformance test corpus: `corpus/valid/` (18 files) and `corpus/invalid/` (56 files)
+
+[Unreleased]: https://github.com/vexil-lang/vexil/commits/master

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,65 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders via GitHub's
+[private vulnerability reporting](https://github.com/vexil-lang/vexil/security/advisories/new)
+or by opening a private discussion with a maintainer.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing to Vexil
+
+Thank you for your interest in contributing! This document explains how to get
+involved, what we expect, and how to get your changes merged.
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Ways to Contribute](#ways-to-contribute)
+- [Development Setup](#development-setup)
+- [Making Changes](#making-changes)
+- [Submitting a Pull Request](#submitting-a-pull-request)
+- [Commit Messages](#commit-messages)
+- [Code Style](#code-style)
+
+---
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant](./CODE_OF_CONDUCT.md).
+By participating, you agree to uphold it.
+
+## Ways to Contribute
+
+- **Bug reports** — open an issue using the bug report template
+- **Feature requests** — open an issue and describe the problem you're solving
+- **Spec clarifications** — corrections or improvements to `spec/vexil-spec.md` or `spec/vexil-grammar.peg`
+- **Corpus additions** — new test cases for `corpus/valid/` or `corpus/invalid/` with a corresponding `MANIFEST.md` entry
+- **Documentation** — typos, clarifications, and examples are always welcome
+- **Code** — see below for how to set up a dev environment
+
+## Development Setup
+
+### Prerequisites
+
+- Rust stable toolchain, 1.80 or later ([install via rustup](https://rustup.rs))
+- `cargo` (included with Rust)
+
+### Build
+
+```sh
+git clone https://github.com/vexil-lang/vexil
+cd vexil
+cargo build --workspace
+```
+
+### Run Tests
+
+```sh
+cargo test --workspace
+```
+
+The test suite includes corpus-driven tests. All 18 valid corpus schemas must
+be accepted and all 56 invalid schemas must be rejected.
+
+### Lint & Format
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --workspace -- -D warnings
+```
+
+Both checks are enforced in CI. Run them locally before pushing.
+
+## Making Changes
+
+1. Fork the repository and create a branch:
+   - Features: `feat/your-feature`
+   - Bug fixes: `fix/your-fix`
+   - Spec/corpus work: `spec/description` or `corpus/description`
+2. Make your changes
+3. Run `cargo test --workspace` and ensure all tests pass
+4. Run `cargo fmt --all` and `cargo clippy --workspace -- -D warnings`
+5. Push and open a pull request
+
+## Submitting a Pull Request
+
+- Keep PRs focused — one concern per PR
+- Add tests for new behavior; for compiler changes, add corpus files where possible
+- Update `corpus/MANIFEST.md` if you add corpus entries
+- Fill in the PR template
+
+## Commit Messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org):
+
+```
+feat(vexil-lang): add @packed annotation support
+fix(vexilc): handle missing file argument gracefully
+docs: clarify §3.4 encoding semantics in spec
+test: add corpus case for duplicate config default
+chore: bump thiserror to 2.1
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf`
+
+Scope is optional but useful: `vexil-lang`, `vexilc`, `spec`, `corpus`.
+
+## Code Style
+
+- Code is formatted with `cargo fmt` (enforced in CI)
+- Clippy lints are treated as errors in CI (`-D warnings`)
+- No `unwrap()` or `expect()` in non-test code — use `?` or explicit error handling
+- All `unsafe` blocks require a `// SAFETY:` comment explaining the invariant
+- Public API items in `vexil-lang` must have doc comments
+- `#[derive(Debug, Clone, PartialEq)]` on all data types unless there is a specific reason not to

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,11 @@
 [workspace]
 resolver = "2"
 members = ["crates/vexil-lang", "crates/vexilc"]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.80"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/vexil-lang/vexil"
+authors = ["Orix Systems contributors"]

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,177 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as submitted to the Licensor for inclusion
+      in the Work by the copyright owner or by an individual or Legal Entity
+      authorized to submit on behalf of the copyright owner. For the purposes
+      of this definition, "submitted" means any form of electronic, verbal,
+      or written communication sent to the Licensor or its representatives,
+      including but not limited to communication on electronic mailing lists,
+      source code control systems, and issue tracking systems that are managed
+      by, or on behalf of, the Licensor for the purpose of discussing and
+      improving the Work, but excluding communication that is conspicuously
+      marked or designated in writing by the copyright owner as "Not a
+      Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and included
+      within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent contributions
+      Licensable by such Contributor that are necessarily infringed by
+      their Contributor submission(s) alone or by combination of their
+      Contributor submission(s) with the Work to which such Contributor
+      submission(s) were submitted. If You institute patent litigation
+      against any entity (including a cross-claim or counterclaim in a
+      lawsuit) alleging that the Work or any such Contribution incorporated
+      within the Work constitutes direct or contributory patent infringement,
+      then any patent licenses granted to You under this License for that
+      Work shall terminate as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or in addition to the
+          NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, reproduce, modify,
+      prepare Derivative Works of, convert to other media types, perform,
+      display, sublicate, and distribute such modifications.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any conditions of TITLE,
+      MERCHANTIBILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+      NONINFRINGEMENT. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (even if such Contributor has been advised of the possibility
+      of such damages).
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may offer only
+      conditions completely consistent with this License.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Orix Systems contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Orix Systems contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,115 @@
+<h1 align="center">Vexil</h1>
+<p align="center"><em>A typed schema definition language with first-class encoding semantics.</em></p>
+
+<p align="center">
+  <a href="https://github.com/vexil-lang/vexil/actions/workflows/ci.yml">
+    <img src="https://github.com/vexil-lang/vexil/actions/workflows/ci.yml/badge.svg" alt="CI">
+  </a>
+  <img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue" alt="License: MIT OR Apache-2.0">
+  <img src="https://img.shields.io/badge/rust-1.80%2B-orange" alt="Rust 1.80+">
+</p>
+
+---
+
+## What is Vexil?
+
+Vexil (Validated Exchange Language) is a schema definition language (SDL) in the tradition of Protocol Buffers and Cap'n Proto, distinguished by two properties:
+
+**Encoding semantics are part of the type system.** The type `u4` means exactly 4 bits on the wire — not "an integer that fits in 4 bits." The annotation `@varint` on a `u64` field changes the wire encoding to unsigned LEB128. The schema is the wire contract, not just the shape contract.
+
+**The schema is the single source of truth.** Each schema has a deterministic BLAKE3 hash. That hash is embedded in generated code as a compile-time constant. A mismatch between the schema a sender compiled against and the schema a receiver compiled against is detectable at runtime, before any data corruption occurs.
+
+## Features
+
+- **Sub-byte integer types** — `u1`..`u7` and `i1`..`i7`; each occupies exactly N bits on the wire with LSB-first bit packing
+- **Encoding annotations** — `@varint` (unsigned LEB128), `@zigzag` (ZigZag + LEB128), `@delta` (delta from previous value) directly in the schema
+- **Rich type vocabulary** — `message`, `enum`, `flags`, `union`, `newtype`, and `config` declarations
+- **Schema versioning** — BLAKE3 hash of the canonical schema form; mismatch is detectable at the protocol boundary
+- **Structured error model** — every invalid input produces a distinct error class with file, line, column, and a human-readable description
+- **74-file conformance corpus** — 18 valid schemas and 56 invalid schemas; a conformant implementation must accept all valid and reject all invalid
+
+## Installation
+
+### Pre-built binaries
+
+Pre-built binaries for Linux, Windows, and macOS are available on the
+[Releases page](https://github.com/vexil-lang/vexil/releases).
+
+### From source
+
+Requires Rust 1.80 or later ([install via rustup](https://rustup.rs)).
+
+```sh
+git clone https://github.com/vexil-lang/vexil
+cd vexil
+cargo build --release --bin vexilc
+# Binary is at target/release/vexilc
+```
+
+## Usage
+
+### CLI
+
+Validate and compile a `.vexil` schema file:
+
+```sh
+vexilc schema.vexil
+```
+
+Errors are rendered with source spans and structured diagnostics:
+
+```
+Error: duplicate field name
+   --> schema.vexil:8:5
+    |
+  8 |     value: u32,
+    |     ^^^^^ field "value" was already declared on line 5
+```
+
+### Library
+
+Add `vexil-lang` to your `Cargo.toml`:
+
+```toml
+[dependencies]
+vexil-lang = { git = "https://github.com/vexil-lang/vexil" }
+```
+
+Parse and compile a schema programmatically:
+
+```rust
+let result = vexil_lang::compile(source);
+if result.diagnostics.iter().any(|d| d.severity == Severity::Error) {
+    // handle errors
+}
+if let Some(compiled) = result.compiled {
+    // use compiled schema
+}
+```
+
+## Repository Structure
+
+```
+spec/
+  vexil-spec.md        # Language specification (normative)
+  vexil-grammar.peg    # Formal PEG grammar derived from spec
+corpus/
+  valid/               # 18 conformant schemas — all must be accepted
+  invalid/             # 56 invalid schemas — all must be rejected
+crates/
+  vexil-lang/          # Compiler library: lexer, parser, IR, type checker
+  vexilc/              # CLI frontend with ariadne error rendering
+```
+
+## Contributing
+
+Contributions are welcome. Please read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a pull request.
+
+## License
+
+Licensed under either of
+
+- [MIT License](./LICENSE-MIT)
+- [Apache License, Version 2.0](./LICENSE-APACHE)
+
+at your option.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| latest (pre-release) | ✅ |
+
+## Reporting a Vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Use GitHub's [private vulnerability reporting](https://github.com/vexil-lang/vexil/security/advisories/new) to submit a report confidentially.
+
+Include in your report:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Any suggested mitigations
+
+You can expect:
+
+- **Acknowledgment** within 48 hours
+- **Status update** within 7 days
+- **Public disclosure** coordinated after a fix is available (typically 90 days)
+
+## Scope
+
+In scope:
+
+- Remote code execution via malicious `.vexil` schema files
+- Memory safety issues in the parser or compiler library
+- Data exposure or corruption in generated code
+
+Out of scope:
+
+- Denial of service via intentional resource exhaustion (e.g., deeply nested schemas)
+- Issues in upstream dependencies — report those to the relevant project

--- a/crates/vexil-lang/Cargo.toml
+++ b/crates/vexil-lang/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "vexil-lang"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.80"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Compiler library for the Vexil schema definition language — lexer, parser, IR, and type checker"
+keywords = ["schema", "serialization", "codegen", "protocol", "compiler"]
+categories = ["compilers", "encoding", "development-tools"]
 
 [dependencies]
 smol_str = "0.3"

--- a/crates/vexilc/Cargo.toml
+++ b/crates/vexilc/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
 name = "vexilc"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.80"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "The Vexil schema compiler CLI"
+publish = false
 
 [dependencies]
 vexil-lang = { path = "../vexil-lang" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

- Adds dual `MIT OR Apache-2.0` license (`LICENSE-MIT` + `LICENSE-APACHE`)
- Adds `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `CHANGELOG.md`
- Adds CI workflow: test + clippy + fmt on Ubuntu and Windows, triggers on `master`
- Adds release workflow: builds `vexilc` binaries for Linux/Windows/macOS on `v*` tags
- Adds Dependabot (cargo + github-actions, weekly)
- Adds `.github/CODEOWNERS`, issue templates (bug + feature), and PR template
- Adds `.editorconfig` and `rust-toolchain.toml` (stable + rustfmt + clippy)
- Consolidates crate metadata into `[workspace.package]`; sets `publish = false` on `vexilc`

## Test plan

- [ ] CI workflow triggers and passes on this PR
- [ ] Verify `.github/ISSUE_TEMPLATE/` forms render correctly in the GitHub UI
- [ ] Enable GitHub private vulnerability reporting (Settings → Security → Advisories) before merging