### PR TITLE
chore(release): v0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "vexil-codegen-rust"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "test-case",
  "thiserror",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "vexil-codegen-ts"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "test-case",
  "thiserror",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "vexil-lang"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "smol_str",
@@ -641,14 +641,14 @@ dependencies = [
 
 [[package]]
 name = "vexil-runtime"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "vexil-store"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "smol_str",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "vexilc"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ariadne",
  "vexil-codegen-rust",

--- a/crates/vexil-codegen-rust/Cargo.toml
+++ b/crates/vexil-codegen-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexil-codegen-rust"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -12,7 +12,7 @@ keywords = ["schema", "codegen", "serialization"]
 categories = ["compilers", "development-tools"]
 
 [dependencies]
-vexil-lang = { path = "../vexil-lang", version = "^0.2.2" }
+vexil-lang = { path = "../vexil-lang", version = "^0.2.3" }
 thiserror = "2"
 
 [dev-dependencies]

--- a/crates/vexil-codegen-ts/CHANGELOG.md
+++ b/crates/vexil-codegen-ts/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+

--- a/crates/vexil-codegen-ts/Cargo.toml
+++ b/crates/vexil-codegen-ts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexil-codegen-ts"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -12,7 +12,7 @@ keywords = ["schema", "codegen", "typescript"]
 categories = ["compilers", "development-tools"]
 
 [dependencies]
-vexil-lang = { path = "../vexil-lang", version = "^0.2.2" }
+vexil-lang = { path = "../vexil-lang", version = "^0.2.3" }
 thiserror = "2"
 
 [dev-dependencies]

--- a/crates/vexil-lang/Cargo.toml
+++ b/crates/vexil-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexil-lang"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/vexil-runtime/Cargo.toml
+++ b/crates/vexil-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexil-runtime"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/vexil-store/Cargo.toml
+++ b/crates/vexil-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexil-store"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -12,8 +12,8 @@ keywords = ["schema", "serialization", "format", "store"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-vexil-lang = { path = "../vexil-lang", version = "^0.2.2" }
-vexil-runtime = { path = "../vexil-runtime", version = "^0.2.2" }
+vexil-lang = { path = "../vexil-lang", version = "^0.2.3" }
+vexil-runtime = { path = "../vexil-runtime", version = "^0.2.3" }
 thiserror = "2"
 blake3 = "1"
 smol_str = "0.3"

--- a/crates/vexilc/Cargo.toml
+++ b/crates/vexilc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexilc"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -12,8 +12,8 @@ keywords = ["schema", "codegen", "compiler", "protocol", "cli"]
 categories = ["compilers", "development-tools", "command-line-utilities"]
 
 [dependencies]
-vexil-lang = { path = "../vexil-lang", version = "^0.2.2" }
-vexil-codegen-rust = { path = "../vexil-codegen-rust", version = "^0.2.2" }
-vexil-codegen-ts = { path = "../vexil-codegen-ts", version = "^0.2.2" }
-vexil-store = { path = "../vexil-store", version = "^0.2.2" }
+vexil-lang = { path = "../vexil-lang", version = "^0.2.3" }
+vexil-codegen-rust = { path = "../vexil-codegen-rust", version = "^0.2.3" }
+vexil-codegen-ts = { path = "../vexil-codegen-ts", version = "^0.2.3" }
+vexil-store = { path = "../vexil-store", version = "^0.2.3" }
 ariadne = "0.6"


### PR DESCRIPTION



## 🤖 New release

* `vexil-lang`: 0.2.2 -> 0.2.3
* `vexil-codegen-rust`: 0.2.2 -> 0.2.3
* `vexil-codegen-ts`: 0.2.2 -> 0.2.3
* `vexil-runtime`: 0.2.2 -> 0.2.3
* `vexil-store`: 0.2.2 -> 0.2.3
* `vexilc`: 0.2.2 -> 0.2.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `vexil-lang`

<blockquote>

## 0.2.0 (2026-03-27)

### New Features

- `meta_schema()` and `pack_schema()` — pre-compiled `vexil.schema` and `vexil.pack` schemas exposed as static references for use by `vexil-store`
- `CodegenBackend` trait — pluggable code generation; implement `generate()` + `generate_project()` to add a new target language
- `CodegenError` — shared error type with `BackendSpecific(Box<dyn Error>)` for backend extensibility
- Multi-file project compiler (`compile_project()`) — resolves transitive imports, detects cycles, deduplicates diamonds
- `SchemaLoader` trait + `FilesystemLoader` + `InMemoryLoader` — abstraction layer for multi-root schema resolution
- `source_file` field on `Diagnostic` — pinpoints errors to the originating file in multi-file compilations

### Bug Fixes

- Transitive type remapping and diamond deduplication in `clone_types_into`
- Aliased import TypeId remapping for cross-file type references
- Reject schemas without a namespace in the import graph (prevents HashMap key collisions)

### API Stability

Stability tiers documented on all public modules. `compile()`, IR types, and `CodegenBackend` are Tier 1 (stable for the v0.x series).
</blockquote>

## `vexil-codegen-rust`

<blockquote>

## 0.2.0 (2026-03-27)

### New Features

- `RustBackend` — implements the `CodegenBackend` trait from `vexil-lang`; supports single-file (`generate()`) and multi-file project (`generate_project()`) code generation
- Cross-file import `use` statements emitted automatically in `generate_project()`

### Bug Fixes

- `generate_with_imports` visibility tightened to `pub(crate)`
- Tier 1 re-exports aligned with `vexil-lang` public API
</blockquote>


## `vexil-runtime`

<blockquote>

## 0.2.0 (2026-03-27)

### Bug Fixes

- `Box<T>` blanket impls for `Pack`/`Unpack` — enables boxing of recursive types in generated code
- Delta-encoded fields now correctly round-trip through `Pack`/`Unpack`
- Union variant payload writer/reader fixed for `Named` type fields
- Config optional defaults now correctly wrapped in `Some()` when non-`None`
</blockquote>

## `vexil-store`

<blockquote>

## 0.1.0 (2026-03-27)

Initial release.

- `encode` / `decode` — schema-driven bitpack encoder and decoder for `Value` trees
- `Value` — dynamically typed value covering all Vexil primitives, composites, and semantic types
- `.vx` text format — human-readable parse and format via `parse()` and `format()`
- `.vxb` binary format — typed file header with magic bytes, format version, schema hash, namespace, and schema version; compressed variant `VXBP` supported
- `detect_format()` — identifies `.vx` vs `.vxb` from file content
- `meta_schema()` / `pack_schema()` — pre-compiled `vexil.schema` and `vexil.pack` schemas for encoding Vexil IR as first-class values
- Wire golden tests — committed exact byte sequences prove cross-platform encoding interoperability on linux x86-64, linux arm64, windows, and macOS arm64
- Signed sub-byte encoding correct — `iN` fields use two's complement in exactly N bits
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).