### PR TITLE
chore(release): bump crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,9 +389,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "vexil-codegen-rust"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "test-case",
  "thiserror",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "vexil-codegen-ts"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "test-case",
  "thiserror",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "vexil-lang"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "blake3",
  "smol_str",
@@ -806,14 +806,14 @@ dependencies = [
 
 [[package]]
 name = "vexil-runtime"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "vexil-store"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "blake3",
  "smol_str",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "vexilc"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "ariadne",
  "serde",
@@ -867,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -880,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -890,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -903,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
 dependencies = [
  "unicode-ident",
 ]
@@ -946,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/vexil-codegen-rust/Cargo.toml
+++ b/crates/vexil-codegen-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexil-codegen-rust"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -12,7 +12,7 @@ keywords = ["schema", "codegen", "serialization"]
 categories = ["compilers", "development-tools"]
 
 [dependencies]
-vexil-lang = { path = "../vexil-lang", version = "^0.2.4" }
+vexil-lang = { path = "../vexil-lang", version = "^0.2.5" }
 thiserror = "2"
 
 [dev-dependencies]

--- a/crates/vexil-codegen-ts/CHANGELOG.md
+++ b/crates/vexil-codegen-ts/CHANGELOG.md
@@ -5,3 +5,4 @@ All notable changes to this project will be documented in this file.
 
 
 
+

--- a/crates/vexil-codegen-ts/Cargo.toml
+++ b/crates/vexil-codegen-ts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexil-codegen-ts"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -12,7 +12,7 @@ keywords = ["schema", "codegen", "typescript"]
 categories = ["compilers", "development-tools"]
 
 [dependencies]
-vexil-lang = { path = "../vexil-lang", version = "^0.2.4" }
+vexil-lang = { path = "../vexil-lang", version = "^0.2.5" }
 thiserror = "2"
 
 [dev-dependencies]

--- a/crates/vexil-lang/Cargo.toml
+++ b/crates/vexil-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexil-lang"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/vexil-runtime/Cargo.toml
+++ b/crates/vexil-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexil-runtime"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/vexil-store/Cargo.toml
+++ b/crates/vexil-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexil-store"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -12,8 +12,8 @@ keywords = ["schema", "serialization", "format", "store"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-vexil-lang = { path = "../vexil-lang", version = "^0.2.4" }
-vexil-runtime = { path = "../vexil-runtime", version = "^0.2.4" }
+vexil-lang = { path = "../vexil-lang", version = "^0.2.5" }
+vexil-runtime = { path = "../vexil-runtime", version = "^0.2.5" }
 thiserror = "2"
 blake3 = "1"
 smol_str = "0.3"

--- a/crates/vexilc/Cargo.toml
+++ b/crates/vexilc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexilc"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -12,10 +12,10 @@ keywords = ["schema", "codegen", "compiler", "protocol", "cli"]
 categories = ["compilers", "development-tools", "command-line-utilities"]
 
 [dependencies]
-vexil-lang = { path = "../vexil-lang", version = "^0.2.4" }
-vexil-codegen-rust = { path = "../vexil-codegen-rust", version = "^0.2.4" }
-vexil-codegen-ts = { path = "../vexil-codegen-ts", version = "^0.2.4" }
-vexil-store = { path = "../vexil-store", version = "^0.2.4" }
+vexil-lang = { path = "../vexil-lang", version = "^0.2.5" }
+vexil-codegen-rust = { path = "../vexil-codegen-rust", version = "^0.2.5" }
+vexil-codegen-ts = { path = "../vexil-codegen-ts", version = "^0.2.5" }
+vexil-store = { path = "../vexil-store", version = "^0.2.5" }
 ariadne = "0.6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION



## 🤖 New release

* `vexil-lang`: 0.2.4 -> 0.2.5
* `vexil-codegen-rust`: 0.2.4 -> 0.2.5
* `vexil-codegen-ts`: 0.2.4 -> 0.2.5
* `vexil-runtime`: 0.2.4 -> 0.2.5
* `vexil-store`: 0.2.4 -> 0.2.5
* `vexilc`: 0.2.4 -> 0.2.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `vexil-lang`

<blockquote>

## 0.2.0 (2026-03-27)

### New Features

- `meta_schema()` and `pack_schema()` — pre-compiled `vexil.schema` and `vexil.pack` schemas exposed as static references for use by `vexil-store`
- `CodegenBackend` trait — pluggable code generation; implement `generate()` + `generate_project()` to add a new target language
- `CodegenError` — shared error type with `BackendSpecific(Box<dyn Error>)` for backend extensibility
- Multi-file project compiler (`compile_project()`) — resolves transitive imports, detects cycles, deduplicates diamonds
- `SchemaLoader` trait + `FilesystemLoader` + `InMemoryLoader` — abstraction layer for multi-root schema resolution
- `source_file` field on `Diagnostic` — pinpoints errors to the originating file in multi-file compilations

### Bug Fixes

- Transitive type remapping and diamond deduplication in `clone_types_into`
- Aliased import TypeId remapping for cross-file type references
- Reject schemas without a namespace in the import graph (prevents HashMap key collisions)

### API Stability

Stability tiers documented on all public modules. `compile()`, IR types, and `CodegenBackend` are Tier 1 (stable for the v0.x series).
</blockquote>

## `vexil-codegen-rust`

<blockquote>

## 0.2.0 (2026-03-27)

### New Features

- `RustBackend` — implements the `CodegenBackend` trait from `vexil-lang`; supports single-file (`generate()`) and multi-file project (`generate_project()`) code generation
- Cross-file import `use` statements emitted automatically in `generate_project()`

### Bug Fixes

- `generate_with_imports` visibility tightened to `pub(crate)`
- Tier 1 re-exports aligned with `vexil-lang` public API
</blockquote>


## `vexil-runtime`

<blockquote>

## 0.2.0 (2026-03-27)

### Bug Fixes

- `Box<T>` blanket impls for `Pack`/`Unpack` — enables boxing of recursive types in generated code
- Delta-encoded fields now correctly round-trip through `Pack`/`Unpack`
- Union variant payload writer/reader fixed for `Named` type fields
- Config optional defaults now correctly wrapped in `Some()` when non-`None`
</blockquote>

## `vexil-store`

<blockquote>

## 0.1.0 (2026-03-27)

Initial release.

- `encode` / `decode` — schema-driven bitpack encoder and decoder for `Value` trees
- `Value` — dynamically typed value covering all Vexil primitives, composites, and semantic types
- `.vx` text format — human-readable parse and format via `parse()` and `format()`
- `.vxb` binary format — typed file header with magic bytes, format version, schema hash, namespace, and schema version; compressed variant `VXBP` supported
- `detect_format()` — identifies `.vx` vs `.vxb` from file content
- `meta_schema()` / `pack_schema()` — pre-compiled `vexil.schema` and `vexil.pack` schemas for encoding Vexil IR as first-class values
- Wire golden tests — committed exact byte sequences prove cross-platform encoding interoperability on linux x86-64, linux arm64, windows, and macOS arm64
- Signed sub-byte encoding correct — `iN` fields use two's complement in exactly N bits
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).