### PR TITLE
fix(vexilc): check --include, prefix-stripped loader, no panic on unresolved TypeId

### DIFF
--- a/crates/vexil-lang/src/canonical.rs
+++ b/crates/vexil-lang/src/canonical.rs
@@ -56,7 +56,6 @@ fn type_str(ty: &ResolvedType, registry: &TypeRegistry) -> String {
             if let Some(def) = registry.get(*id) {
                 type_def_name(def).to_owned()
             } else {
-                debug_assert!(false, "unresolved TypeId {:?} in canonical form", id);
                 "<unresolved>".to_owned()
             }
         }
@@ -125,7 +124,7 @@ fn type_def_name(def: &TypeDef) -> &str {
         TypeDef::Newtype(d) => d.name.as_str(),
         TypeDef::Config(d) => d.name.as_str(),
         _ => {
-            debug_assert!(false, "unknown TypeDef variant in canonical form");
+            // Unknown TypeDef variant — skip in canonical form.
             "<unknown>"
         }
     }
@@ -240,7 +239,6 @@ fn emit_tombstones(out: &mut String, tombstones: &[TombstoneDef]) {
 
 fn emit_type_def(out: &mut String, type_id: TypeId, registry: &TypeRegistry) {
     let Some(def) = registry.get(type_id) else {
-        debug_assert!(false, "unresolved TypeId {:?} in canonical form", type_id);
         return;
     };
     #[allow(unreachable_patterns)]
@@ -468,7 +466,7 @@ fn emit_type_def(out: &mut String, type_id: TypeId, registry: &TypeRegistry) {
             }
         }
         _ => {
-            debug_assert!(false, "unknown TypeDef variant in canonical form");
+            // Unknown TypeDef variant — skip in canonical form.
         }
     }
 }

--- a/crates/vexil-lang/src/resolve.rs
+++ b/crates/vexil-lang/src/resolve.rs
@@ -123,20 +123,34 @@ impl FilesystemLoader {
 impl SchemaLoader for FilesystemLoader {
     fn load(&self, namespace: &[&str]) -> Result<(String, PathBuf), LoadError> {
         let dotted = namespace.join(".");
-        // Build the relative path: segments joined by OS sep, ".vexil" extension.
-        let mut rel = PathBuf::new();
-        for seg in namespace {
-            rel.push(seg);
-        }
-        rel.set_extension("vexil");
 
-        // Collect every root that contains the file.
-        let mut found: Vec<PathBuf> = self
-            .roots
-            .iter()
-            .map(|root| root.join(&rel))
-            .filter(|p| p.is_file())
-            .collect();
+        // Try progressively shorter relative paths by stripping leading
+        // namespace segments.  This allows an `--include` directory to sit
+        // at any level of the namespace hierarchy:
+        //
+        //   namespace = ["malt", "common"]
+        //   tries:  malt/common.vexil   (full path)
+        //           common.vexil         (prefix-stripped)
+        let mut found: Vec<PathBuf> = Vec::new();
+        for start in 0..namespace.len() {
+            let mut rel = PathBuf::new();
+            for seg in &namespace[start..] {
+                rel.push(seg);
+            }
+            rel.set_extension("vexil");
+
+            for root in &self.roots {
+                let candidate = root.join(&rel);
+                if candidate.is_file() && !found.contains(&candidate) {
+                    found.push(candidate);
+                }
+            }
+
+            // Stop as soon as we find at least one match at this depth.
+            if !found.is_empty() {
+                break;
+            }
+        }
 
         match found.len() {
             0 => Err(LoadError::NotFound { namespace: dotted }),
@@ -236,6 +250,39 @@ mod tests {
                 if namespace == "net.types.core" && paths.len() == 2),
             "expected Ambiguous with 2 paths, got {err:?}"
         );
+    }
+
+    #[test]
+    fn filesystem_loader_prefix_stripped() {
+        // Include dir sits inside the namespace hierarchy:
+        // namespace "malt.common" but file is at <root>/common.vexil
+        let dir = tempdir();
+        let file = dir.path().join("common.vexil");
+        fs::write(&file, "namespace malt.common").unwrap();
+
+        let loader = FilesystemLoader::new([dir.path()]);
+        let (src, path) = loader.load(&["malt", "common"]).unwrap();
+        assert!(src.contains("malt.common"));
+        assert_eq!(path, file);
+    }
+
+    #[test]
+    fn filesystem_loader_prefers_full_path_over_stripped() {
+        // If both full path and stripped path exist, full path wins.
+        let dir = tempdir();
+        let nested = dir.path().join("malt");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(nested.join("common.vexil"), "namespace malt.common (full)").unwrap();
+        // Also create a stripped version at root
+        fs::write(
+            dir.path().join("common.vexil"),
+            "namespace malt.common (stripped)",
+        )
+        .unwrap();
+
+        let loader = FilesystemLoader::new([dir.path()]);
+        let (src, _) = loader.load(&["malt", "common"]).unwrap();
+        assert!(src.contains("(full)"), "should prefer full path match");
     }
 
     // ── helpers ───────────────────────────────────────────────────────────

--- a/crates/vexilc/src/main.rs
+++ b/crates/vexilc/src/main.rs
@@ -21,7 +21,7 @@ fn render_diagnostic(filename: &str, source: &str, diag: &Diagnostic) {
         .ok();
 }
 
-fn cmd_check(filename: &str) -> i32 {
+fn cmd_check(filename: &str, include_paths: &[String]) -> i32 {
     let source = match std::fs::read_to_string(filename) {
         Ok(s) => s,
         Err(e) => {
@@ -29,21 +29,77 @@ fn cmd_check(filename: &str) -> i32 {
             return 1;
         }
     };
-    let result = vexil_lang::compile(&source);
-    for diag in &result.diagnostics {
-        render_diagnostic(filename, &source, diag);
+
+    // Detect import statements — if present, --include is needed for full
+    // type resolution.  Without it, imported types become unresolved stubs.
+    let has_imports = source.lines().any(|line| {
+        let trimmed = line.trim();
+        trimmed.starts_with("import ")
+    });
+
+    if include_paths.is_empty() && has_imports {
+        eprintln!(
+            "warning: {filename} contains import statements but no --include paths were given"
+        );
+        eprintln!("hint: use `vexilc check {filename} --include <dir>` to resolve imports");
     }
-    if result
-        .diagnostics
-        .iter()
-        .any(|d| d.severity == Severity::Error)
-    {
-        return 1;
-    }
-    if let Some(ref compiled) = result.compiled {
-        let hash = vexil_lang::canonical::schema_hash(compiled);
-        let hex: String = hash.iter().map(|b| format!("{b:02x}")).collect();
-        println!("schema hash: {hex}");
+
+    if include_paths.is_empty() {
+        // Single-file mode
+        let result = vexil_lang::compile(&source);
+        for diag in &result.diagnostics {
+            render_diagnostic(filename, &source, diag);
+        }
+        if result
+            .diagnostics
+            .iter()
+            .any(|d| d.severity == Severity::Error)
+        {
+            return 1;
+        }
+        if let Some(ref compiled) = result.compiled {
+            if !has_imports {
+                let hash = vexil_lang::canonical::schema_hash(compiled);
+                let hex: String = hash.iter().map(|b| format!("{b:02x}")).collect();
+                println!("schema hash: {hex}");
+            }
+        }
+    } else {
+        // Multi-file mode with --include
+        let root_path = std::path::PathBuf::from(filename);
+        let include_dirs: Vec<std::path::PathBuf> =
+            include_paths.iter().map(std::path::PathBuf::from).collect();
+        let loader = vexil_lang::resolve::FilesystemLoader::new(include_dirs);
+
+        let result = match vexil_lang::compile_project(&source, &root_path, &loader) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("error: {e}");
+                return 1;
+            }
+        };
+
+        let has_errors = result
+            .diagnostics
+            .iter()
+            .any(|d| d.severity == Severity::Error);
+        for diag in &result.diagnostics {
+            let file = diag
+                .source_file
+                .as_ref()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|| filename.to_string());
+            let severity = match diag.severity {
+                Severity::Error => "error",
+                Severity::Warning => "warning",
+            };
+            eprintln!("{severity}: {file}: {}", diag.message);
+        }
+        if has_errors {
+            return 1;
+        }
+
+        eprintln!("check passed: {} schemas compiled", result.schemas.len());
     }
     0
 }
@@ -828,7 +884,7 @@ fn cmd_watch(root_file: &str, target: &str, output: Option<&str>, includes: &[St
     println!("[watch] Initial build...");
     let code = match output {
         Some(out) => cmd_build(root_file, includes, out, target),
-        None => cmd_check(root_file),
+        None => cmd_check(root_file, includes),
     };
     if code == 0 {
         println!("[watch] Ready. Watching for changes...");
@@ -903,7 +959,7 @@ fn cmd_watch(root_file: &str, target: &str, output: Option<&str>, includes: &[St
                 println!("\n[watch] Change detected, rebuilding...");
                 let code = match output {
                     Some(out) => cmd_build(root_file, includes, out, target),
-                    None => cmd_check(root_file),
+                    None => cmd_check(root_file, includes),
                 };
                 if code == 0 {
                     println!("[watch] OK");
@@ -940,11 +996,29 @@ fn main() {
 
     match args.get(1).map(|s| s.as_str()) {
         Some("check") => {
-            if args.len() != 3 {
-                eprintln!("Usage: vexilc check <file.vexil>");
+            if args.len() < 3 {
+                eprintln!("Usage: vexilc check <file.vexil> [--include <dir> ...]");
                 std::process::exit(1);
             }
-            std::process::exit(cmd_check(&args[2]));
+            let filename = &args[2];
+            let mut include_paths = Vec::new();
+            let mut i = 3;
+            while i < args.len() {
+                match args[i].as_str() {
+                    "--include" => {
+                        i += 1;
+                        if i < args.len() {
+                            include_paths.push(args[i].clone());
+                        }
+                    }
+                    other => {
+                        eprintln!("unknown option: {other}");
+                        std::process::exit(1);
+                    }
+                }
+                i += 1;
+            }
+            std::process::exit(cmd_check(filename, &include_paths));
         }
         Some("compile") => {
             // vexilc compile <file.vexil> -o <out.vxc|out.vxcp>


### PR DESCRIPTION
## Summary

- **#45**: `vexilc check` now accepts `--include <dir>` (repeatable) for multi-file schema validation without a full build. When imports are detected but no `--include` is given, emits a warning and skips hash computation instead of crashing.
- **#46**: `FilesystemLoader` tries progressively shorter relative paths — `malt.common` resolves to `common.vexil` when the include dir already represents the `malt` prefix.
- **#47**: Removed `debug_assert!(false, ...)` in `canonical.rs` that panicked on unresolved TypeIds in debug builds.

Closes #45, closes #46, closes #47

## Test plan

- [x] New tests: `filesystem_loader_prefix_stripped`, `filesystem_loader_prefers_full_path_over_stripped`
- [x] `cargo test --workspace` — all pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)