### PR TITLE
fix(dist): add protoc system dependency for release builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "vexil-codegen-go"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "test-case",
  "thiserror",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "vexil-codegen-rust"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "test-case",
  "thiserror",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "vexil-codegen-ts"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "test-case",
  "thiserror",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "vexil-lang"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "blake3",
  "smol_str",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "vexil-runtime"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "thiserror",
 ]
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "vexilc"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ariadne",
  "notify",

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -22,6 +22,16 @@ install-path = "CARGO_HOME"
 allow-dirty = ["ci"]
 # Run cargo-dist on Release PRs to verify builds
 pr-run-mode = "upload"
+# System dependencies required by workspace crates (vexil-bench needs protoc)
+[dist.dependencies.apt]
+protobuf-compiler = { version = "*", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"] }
+
+[dist.dependencies.homebrew]
+protobuf = { targets = ["x86_64-apple-darwin", "aarch64-apple-darwin"] }
+
+[dist.dependencies.chocolatey]
+protoc = { version = "*", targets = ["x86_64-pc-windows-msvc"] }
+
 # Customize GitHub runners for ARM Linux
 [dist.github-custom-runners]
 aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"


### PR DESCRIPTION
## Summary

- Add `[dist.dependencies]` in `dist-workspace.toml` for `protobuf-compiler` (apt), `protobuf` (homebrew), and `protoc` (chocolatey)
- cargo-dist's `${{ matrix.packages_install }}` step now installs protoc on all release platforms
- Fixes the `vexil-bench` prost-build failure that blocked all release builds

## Test plan

- [x] `dist plan` confirms `packages_install` includes protoc for all 5 targets
- [ ] Release workflow builds succeed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)